### PR TITLE
docker exec -it CONTAINER_ID /bin/sh equivalent added to commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 ## Usage
 
 - `dbash`: `docker exec -it CONTAINER_ID /bin/bash`
-- `dsh`: `docker exec -it CONTAINER_ID /bin/sh`
 - `dlogs`: `docker logs --follow CONTAINER_ID`
 - `drestart`: `docker restart CONTAINER_ID`
+- `dsh`: `docker exec -it CONTAINER_ID /bin/sh`
 - `dstop`: `docker stop CONTAINER_ID`
 
 ![](public/usage.gif)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ## Usage
 
 - `dbash`: `docker exec -it CONTAINER_ID /bin/bash`
+- `dsh`: `docker exec -it CONTAINER_ID /bin/sh`
 - `dlogs`: `docker logs --follow CONTAINER_ID`
 - `drestart`: `docker restart CONTAINER_ID`
 - `dstop`: `docker stop CONTAINER_ID`

--- a/bin/docker-sh.js
+++ b/bin/docker-sh.js
@@ -1,0 +1,7 @@
+#! /usr/bin/env node
+
+const dockerCommand = require('../src/docker-command');
+
+const dockerSh = dockerId => ['exec', '-it', dockerId,'/bin/sh'];
+
+dockerCommand(dockerSh, true);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "bin": {
     "dbash": "bin/docker-bash.js",
+    "dsh": "bin/docker-sh.js",
     "dlogs": "bin/docker-logs.js",
     "drestart": "bin/docker-restart.js",
     "dstop": "bin/docker-stop.js"

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   },
   "bin": {
     "dbash": "bin/docker-bash.js",
-    "dsh": "bin/docker-sh.js",
     "dlogs": "bin/docker-logs.js",
     "drestart": "bin/docker-restart.js",
+    "dsh": "bin/docker-sh.js",
     "dstop": "bin/docker-stop.js"
   }
 }


### PR DESCRIPTION
Hi!
Awesome tool, but there is a lot of containers, that use lightweight Linux distributions like alpine.
And often they're missing `bash`, so only `sh` is available.
I've added `docker exec -it CONTAINER_ID /bin/sh` for that cases.